### PR TITLE
从StackView中删除添加的subView

### DIFF
--- a/FDStackView/FDStackView.m
+++ b/FDStackView/FDStackView.m
@@ -110,6 +110,7 @@
     }
     [self removeHiddenObserverForView:view];
     [self.mutableArrangedSubviews removeObject:view];
+    [view removeFromSuperview];
     [self.alignmentArrangement removeItem:view];
     [self.distributionArrangement removeItem:view];
     [self updateLayoutArrangements];


### PR DESCRIPTION
我在TableViewCell中使用StackView 重用时会出现重复添加view的问题，发现在addArrangedSubView 或
insertArrangedSubview:atIndex: 中 调用了 [self addSubview:view] 或 [self
insertSubview:view atIndex:stackIndex] 但并没有在removeArrangedSubview:
中删除添加的view
